### PR TITLE
Add T-shirt body color support and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - ⚙️ **カスタマイズ可能**: 線数・角度・網点形状を詳細設定
 - 🚀 **一括処理**: フォルダ内の画像を一括変換
 - 🎨 **多形式対応**: PNG・TIFF・PDF・AI形式での出力
+- 👕 **Tシャツ対応**: 白・黒のTシャツボディに応じた最適処理
   
 ## 🚀 クイックスタート
 
@@ -75,8 +76,11 @@ pip install -r requirements-dev.txt
 ### 基本的な使用方法
 
 ```bash
-# 基本変換（推奨設定）
+# 基本変換（推奨設定・白Tシャツ用）
 python silkscreen_converter.py photo.jpg -o output.png
+
+# 黒Tシャツ用変換（画像を反転処理）
+python silkscreen_converter.py photo.jpg -o output.png --body-color black
 
 # AI形式で出力（Illustratorで編集可能）
 python silkscreen_converter.py photo.jpg -o design.ai --format AI
@@ -88,8 +92,11 @@ python silkscreen_converter.py photo.jpg -o print.pdf --format PDF
 ### 詳細設定での変換
 
 ```bash
-# Tシャツくん用設定（10-15線推奨）
+# Tシャツくん用設定（10-15線推奨・白Tシャツ）
 python silkscreen_converter.py photo.jpg --lines 15 --angle 45 --shape circle
+
+# 黒Tシャツ用設定（画像反転処理）
+python silkscreen_converter.py photo.jpg --lines 15 --angle 45 --body-color black
 
 # 高精細製版用設定
 python silkscreen_converter.py photo.jpg --lines 20 --dpi 600 --format TIFF
@@ -101,8 +108,11 @@ python silkscreen_converter.py photo.jpg --contrast 1.5 --brightness 10
 ### 一括変換（バッチ処理）
 
 ```bash
-# フォルダ内の全画像を一括変換
+# フォルダ内の全画像を一括変換（白Tシャツ用）
 python silkscreen_converter.py images/ --batch --lines 15
+
+# 黒Tシャツ用一括変換
+python silkscreen_converter.py images/ --batch --lines 15 --body-color black
 
 # AI形式で一括変換
 python silkscreen_converter.py photos/ --batch --format AI --lines 15
@@ -120,6 +130,7 @@ python silkscreen_converter.py photos/ --batch --format AI --lines 15
 | `--brightness` | 明度調整 | 0 | -50 to 50 |
 | `--dpi` | 出力解像度 | 300 | 72-1200 |
 | `--format` | 出力形式 | PNG | PNG/TIFF/PDF/AI |
+| `--body-color` | Tシャツボディ色 | white | white/black |
 | `--batch` | 一括変換モード | - | フラグ |
 
 ## 📄 出力形式の比較
@@ -130,6 +141,30 @@ python silkscreen_converter.py photos/ --batch --format AI --lines 15
 | **TIFF** | 印刷用ラスター | 高品質印刷 | ❌ | ❌ |
 | **PDF** | ベクター・印刷最適 | 製版サービス入稿 | ✅ | ⚠️ |
 | **AI** | ベクター・編集可能 | Illustratorで編集 | ✅ | ✅ |
+
+## 👕 Tシャツボディ色別設定ガイド
+
+シルクスクリーンでは、Tシャツのボディ色によって処理方法が異なります：
+
+### 白Tシャツ（デフォルト）
+- **設定**: `--body-color white`（省略可）
+- **処理**: 通常処理（暗い部分がインクになる）
+- **出力**: `photo_silkscreen_white.png`
+- **用途**: 明るい色のTシャツ全般
+
+### 黒Tシャツ
+- **設定**: `--body-color black`
+- **処理**: 画像反転（明るい部分がインクになる）
+- **出力**: `photo_silkscreen_black.png`
+- **用途**: 濃い色のTシャツ全般
+
+```bash
+# 白Tシャツ用（通常処理）
+python silkscreen_converter.py photo.jpg --body-color white
+
+# 黒Tシャツ用（反転処理）
+python silkscreen_converter.py photo.jpg --body-color black
+```
 
 ## 🎯 線数設定ガイド
 
@@ -169,26 +204,38 @@ silkscreen-photo-converter/
 ls photos/
 # sample1.jpg  sample2.png  sample3.webp
 
-# 2. テスト変換（1枚）
+# 2. テスト変換（1枚・白Tシャツ用）
 python silkscreen_converter.py photos/sample1.jpg --lines 15
 
-# 3. 設定を調整
+# 3. 黒Tシャツ用テスト
+python silkscreen_converter.py photos/sample1.jpg --lines 15 --body-color black
+
+# 4. 設定を調整
 python silkscreen_converter.py photos/sample1.jpg --lines 15 --contrast 1.2
 
-# 4. 一括変換
+# 5. 一括変換
 python silkscreen_converter.py photos/ --batch --lines 15 --format AI
 ```
 
 ### 製版サービス入稿用
 
 ```bash
-# 高解像度PDF（製版サービス用）
+# 高解像度PDF（製版サービス用・白Tシャツ）
 python silkscreen_converter.py design.jpg \
   --format PDF \
   --dpi 600 \
   --lines 20 \
   --contrast 1.1 \
-  -o final_design.pdf
+  --body-color white \
+  -o final_design_white.pdf
+
+# 黒Tシャツ用製版データ
+python silkscreen_converter.py design.jpg \
+  --format PDF \
+  --dpi 600 \
+  --lines 20 \
+  --body-color black \
+  -o final_design_black.pdf
 ```
 
 ### Illustratorでの編集用

--- a/silkscreen_converter.py
+++ b/silkscreen_converter.py
@@ -373,11 +373,12 @@ class SilkscreenConverter:
         brightness=0,
         dpi=300,
         format_type="PNG",
+        body_color="white",
     ):
         """メイン変換処理"""
 
         click.echo(f"🔄 変換開始: {input_path}")
-        click.echo(f"   設定 - 線数: {lines}, 角度: {angle}°, 形状: {dot_shape}")
+        click.echo(f"   設定 - 線数: {lines}, 角度: {angle}°, 形状: {dot_shape}, Tシャツ: {body_color}")
 
         # ベクター出力が必要かどうかを判定
         vector_output = format_type.upper() in ["AI", "PDF"]
@@ -401,11 +402,17 @@ class SilkscreenConverter:
         )
         click.echo("🔄 網点処理完了")
 
-        # 5. モノクロ2階調変換
+        # 5. Tシャツボディ色に応じた処理
+        if body_color.lower() == "black":
+            # 黒Tシャツ用: 画像を反転（明るい部分がインクになる）
+            halftone_image = halftone_image.point(lambda x: 255 - x)
+            click.echo("🔄 黒Tシャツ用画像反転完了")
+        
+        # 6. モノクロ2階調変換
         final_image = self.to_monochrome_bitmap(halftone_image)
         click.echo("🔄 モノクロ2階調変換完了")
 
-        # 6. 形式別保存
+        # 7. 形式別保存
         if format_type.upper() == "PDF":
             self.save_pdf(final_image, output_path, dpi)
         elif format_type.upper() == "AI":
@@ -448,6 +455,13 @@ class SilkscreenConverter:
     help="出力形式 (デフォルト: PNG)",
 )
 @click.option("--batch", is_flag=True, help="フォルダ内の全画像を一括変換")
+@click.option(
+    "--body-color",
+    "body_color",
+    type=click.Choice(["white", "black"]),
+    default="white",
+    help="Tシャツのボディ色 (デフォルト: white)",
+)
 def main(
     input_path,
     output_path,
@@ -459,6 +473,7 @@ def main(
     dpi,
     format_type,
     batch,
+    body_color,
 ):
     """
     シルクスクリーン用写真変換ツール（AI・PDF対応版）
@@ -474,7 +489,8 @@ def main(
     例:
       python silkscreen_converter.py photo.jpg -o output.ai --format AI
       python silkscreen_converter.py photo.jpg -o output.pdf --format PDF
-      python silkscreen_converter.py images/ --batch --format AI --lines 15
+      python silkscreen_converter.py photo.jpg --body-color black
+      python silkscreen_converter.py images/ --batch --format AI --lines 15 --body-color white
     """
 
     # 必要なライブラリチェック
@@ -511,7 +527,7 @@ def main(
             else:
                 ext = format_type.lower()
 
-            output_file = os.path.join(input_path, f"{name}_silkscreen.{ext}")
+            output_file = os.path.join(input_path, f"{name}_silkscreen_{body_color}.{ext}")
 
             try:
                 converter.convert(
@@ -524,6 +540,7 @@ def main(
                     brightness,
                     dpi,
                     format_type,
+                    body_color,
                 )
             except Exception as e:
                 click.echo(f"❌ エラー ({file}): {e}")
@@ -538,7 +555,7 @@ def main(
             ext = "svg"
         else:
             ext = format_type.lower()
-        output_path = f"{name}_silkscreen.{ext}"
+        output_path = f"{name}_silkscreen_{body_color}.{ext}"
 
     # バリデーション
     if lines < 5 or lines > 50:
@@ -562,6 +579,7 @@ def main(
             brightness,
             dpi,
             format_type,
+            body_color,
         )
 
         # 形式別の追加情報


### PR DESCRIPTION
Adds support for different T-shirt body colors in silkscreen processing

## Changes
- Add `--body-color` command line option (white/black)
- Implement image inversion for black T-shirt bodies
- Update output filenames to include body color suffix
- Add comprehensive documentation in README.md
- Include usage examples for both white and black T-shirts

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)